### PR TITLE
Fix typo in README template

### DIFF
--- a/templates/README.md.j2
+++ b/templates/README.md.j2
@@ -8,12 +8,12 @@
 
 ## [Example Playbook](#example-playbook)
 
-This example is taken from `molecule/resources/converge.yml` and is tested on each push, pull request and release.
+This example is taken from `molecule/default/converge.yml` and is tested on each push, pull request and release.
 ```yaml
 {{ example.content | b64decode | regex_replace('ansible-role-', galaxy_namespace ~ '.') }}```
 
 {% if prepare.content is defined %}
-The machine needs to be prepared in CI this is done using `molecule/resources/prepare.yml`:
+The machine needs to be prepared in CI this is done using `molecule/default/prepare.yml`:
 ```yaml
 {{ prepare.content | b64decode | regex_replace('ansible-role-', galaxy_namespace ~ '.') }}```
 


### PR DESCRIPTION
I corrected the path `molecule/resources` to `molecule/default`
